### PR TITLE
HELP-20839 get user part of possible returned uri

### DIFF
--- a/applications/ecallmgr/src/ecallmgr_util.erl
+++ b/applications/ecallmgr/src/ecallmgr_util.erl
@@ -194,10 +194,12 @@ get_sip_from(Props, _) ->
 %% retrieves the sip address for the 'request' field
 -spec get_sip_request(wh_proplist()) -> ne_binary().
 get_sip_request(Props) ->
-    User = props:get_first_defined([<<"Hunt-Destination-Number">>
-                                    ,<<"variable_sip_req_uri">>
-                                    ,<<"variable_sip_to_user">>
-                                   ], Props, <<"nouser">>),
+    [User | _] = binary:split(
+                   props:get_first_defined(
+                     [<<"Hunt-Destination-Number">>
+                      ,<<"variable_sip_req_uri">>
+                      ,<<"variable_sip_to_user">>
+                     ], Props, <<"nouser">>), <<"@">>, ['global']),
     Realm = props:get_first_defined([?GET_CCV(<<"Realm">>)
                                      ,<<"variable_sip_auth_realm">>
                                      ,<<"variable_sip_to_host">>


### PR DESCRIPTION
it seems that some users are using the request in webhooks for some reason.
the value expressed here may change in the future to something like sip:user_xxxxx@X.Y.W.Z:1028;transport=udp
please use derived values like caller_id/callee_id and/or others.